### PR TITLE
Make state and rewards like the Presslight paper

### DIFF
--- a/agent/dqn.py
+++ b/agent/dqn.py
@@ -7,7 +7,7 @@ import random
 from collections import deque
 import gym
 
-from generator import LaneVehicleGenerator, IntersectionPhaseGenerator, IntersectionVehicleGenerator
+from generator import LaneVehicleGenerator, IntersectionPhaseGenerator, IntersectionVehicleGenerator, SegmentedLaneGenerator
 
 import torch
 from torch import nn
@@ -41,7 +41,7 @@ if mode == 'dqn':
             inter_id = self.world.intersection_ids[self.rank]
             inter_obj = self.world.id2intersection[inter_id]
             self.inter = inter_obj
-            self.ob_generator = LaneVehicleGenerator(self.world, self.inter, ['lane_count'], in_only=False, average=None)
+            self.ob_generator = SegmentedLaneGenerator(self.world, self.inter, ['segmented_lane_count'], in_only=False, average=None)
 
             self.phase_generator = IntersectionPhaseGenerator(world, self.inter, ["phase"],
                                                               targets=["cur_phase"], negative=False)
@@ -93,7 +93,7 @@ if mode == 'dqn':
             '''
             inter_id = self.world.intersection_ids[self.rank]
             inter_obj = self.world.id2intersection[inter_id]
-            self.ob_generator = LaneVehicleGenerator(self.world, inter_obj, ['lane_count'], in_only=False, average=None)
+            self.ob_generator = SegmentedLaneGenerator(self.world, self.inter, ['segmented_lane_count'], in_only=False, average=None)
             self.phase_generator = IntersectionPhaseGenerator(self.world, inter_obj, ["phase"],
                                                               targets=["cur_phase"], negative=False)
             self.reward_generator = LaneVehicleGenerator(self.world, inter_obj, ["pressure"], average="all", negative=True)
@@ -426,7 +426,7 @@ elif mode == 'ac_dqn':
             inter_id = self.world.intersection_ids[self.rank]
             inter_obj = self.world.id2intersection[inter_id]
             self.inter = inter_obj
-            self.ob_generator = LaneVehicleGenerator(self.world, self.inter, ['lane_count'], in_only=False, average=None)
+            self.ob_generator = SegmentedLaneGenerator(self.world, self.inter, ['segmented_lane_count'], in_only=False, average=None)
             self.phase_generator = IntersectionPhaseGenerator(world, self.inter, ["phase"],
                                                               targets=["cur_phase"], negative=False)
             self.reward_generator = LaneVehicleGenerator(world, inter_obj, ["pressure"], average="all", negative=True)
@@ -480,7 +480,7 @@ elif mode == 'ac_dqn':
             '''
             inter_id = self.world.intersection_ids[self.rank]
             inter_obj = self.world.id2intersection[inter_id]
-            self.ob_generator = LaneVehicleGenerator(self.world, inter_obj, ['lane_count'], in_only=True, average=None)
+            self.ob_generator = SegmentedLaneGenerator(self.world, self.inter, ['segmented_lane_count'], in_only=False, average=None)
             self.phase_generator = IntersectionPhaseGenerator(self.world, inter_obj, ["phase"],
                                                               targets=["cur_phase"], negative=False)
             self.reward_generator = LaneVehicleGenerator(self.world, inter_obj, ["pressure"], average="all", negative=True)

--- a/agent/dqn.py
+++ b/agent/dqn.py
@@ -41,7 +41,7 @@ if mode == 'dqn':
             inter_id = self.world.intersection_ids[self.rank]
             inter_obj = self.world.id2intersection[inter_id]
             self.inter = inter_obj
-            self.ob_generator = LaneVehicleGenerator(self.world, self.inter, ['lane_count'], in_only=True, average=None)
+            self.ob_generator = LaneVehicleGenerator(self.world, self.inter, ['lane_count'], in_only=False, average=None)
 
             self.phase_generator = IntersectionPhaseGenerator(world, self.inter, ["phase"],
                                                               targets=["cur_phase"], negative=False)
@@ -93,7 +93,7 @@ if mode == 'dqn':
             '''
             inter_id = self.world.intersection_ids[self.rank]
             inter_obj = self.world.id2intersection[inter_id]
-            self.ob_generator = LaneVehicleGenerator(self.world, inter_obj, ['lane_count'], in_only=True, average=None)
+            self.ob_generator = LaneVehicleGenerator(self.world, inter_obj, ['lane_count'], in_only=False, average=None)
             self.phase_generator = IntersectionPhaseGenerator(self.world, inter_obj, ["phase"],
                                                               targets=["cur_phase"], negative=False)
             self.reward_generator = LaneVehicleGenerator(self.world, inter_obj, ["pressure"], average="all", negative=True)
@@ -426,8 +426,7 @@ elif mode == 'ac_dqn':
             inter_id = self.world.intersection_ids[self.rank]
             inter_obj = self.world.id2intersection[inter_id]
             self.inter = inter_obj
-            self.ob_generator = LaneVehicleGenerator(self.world, self.inter, ['lane_count'], in_only=True, average=None)
-
+            self.ob_generator = LaneVehicleGenerator(self.world, self.inter, ['lane_count'], in_only=False, average=None)
             self.phase_generator = IntersectionPhaseGenerator(world, self.inter, ["phase"],
                                                               targets=["cur_phase"], negative=False)
             self.reward_generator = LaneVehicleGenerator(world, inter_obj, ["pressure"], average="all", negative=True)

--- a/agent/dqn.py
+++ b/agent/dqn.py
@@ -45,8 +45,7 @@ if mode == 'dqn':
 
             self.phase_generator = IntersectionPhaseGenerator(world, self.inter, ["phase"],
                                                               targets=["cur_phase"], negative=False)
-            self.reward_generator = LaneVehicleGenerator(self.world, self.inter, ["lane_waiting_count"],
-                                                         in_only=True, average='all', negative=True)
+            self.reward_generator = LaneVehicleGenerator(world, inter_obj, ["pressure"], average="all", negative=True)
             self.action_space = gym.spaces.Discrete(len(self.world.id2intersection[inter_id].phases))
 
             if self.phase:
@@ -97,8 +96,7 @@ if mode == 'dqn':
             self.ob_generator = LaneVehicleGenerator(self.world, inter_obj, ['lane_count'], in_only=True, average=None)
             self.phase_generator = IntersectionPhaseGenerator(self.world, inter_obj, ["phase"],
                                                               targets=["cur_phase"], negative=False)
-            self.reward_generator = LaneVehicleGenerator(self.world, inter_obj, ["lane_waiting_count"],
-                                                         in_only=True, average='all', negative=True)
+            self.reward_generator = LaneVehicleGenerator(self.world, inter_obj, ["pressure"], average="all", negative=True)
             self.queue = LaneVehicleGenerator(self.world, inter_obj,
                                               ["lane_waiting_count"], in_only=True,
                                               negative=False)
@@ -432,8 +430,7 @@ elif mode == 'ac_dqn':
 
             self.phase_generator = IntersectionPhaseGenerator(world, self.inter, ["phase"],
                                                               targets=["cur_phase"], negative=False)
-            self.reward_generator = LaneVehicleGenerator(self.world, self.inter, ["lane_waiting_count"],
-                                                         in_only=True, average='all', negative=True)
+            self.reward_generator = LaneVehicleGenerator(world, inter_obj, ["pressure"], average="all", negative=True)
             self.action_space = gym.spaces.Discrete(len(self.world.id2intersection[inter_id].phases))
 
             if self.phase:
@@ -487,8 +484,7 @@ elif mode == 'ac_dqn':
             self.ob_generator = LaneVehicleGenerator(self.world, inter_obj, ['lane_count'], in_only=True, average=None)
             self.phase_generator = IntersectionPhaseGenerator(self.world, inter_obj, ["phase"],
                                                               targets=["cur_phase"], negative=False)
-            self.reward_generator = LaneVehicleGenerator(self.world, inter_obj, ["lane_waiting_count"],
-                                                         in_only=True, average='all', negative=True)
+            self.reward_generator = LaneVehicleGenerator(self.world, inter_obj, ["pressure"], average="all", negative=True)
             self.queue = LaneVehicleGenerator(self.world, inter_obj,
                                               ["lane_waiting_count"], in_only=True,
                                               negative=False)

--- a/generator/__init__.py
+++ b/generator/__init__.py
@@ -1,4 +1,4 @@
 from .base import BaseGenerator
-from .lane_vehicle import LaneVehicleGenerator
+from .lane_vehicle import LaneVehicleGenerator, SegmentedLaneGenerator
 from .intersection_vehicle import IntersectionVehicleGenerator
 from .intersection_phase import IntersectionPhaseGenerator

--- a/generator/lane_vehicle.py
+++ b/generator/lane_vehicle.py
@@ -182,6 +182,41 @@ class LaneVehicleGenerator(BaseGenerator):
             ret = np.array(ret_list)
         return ret
 
+class SegmentedLaneGenerator(LaneVehicleGenerator):
+    def __init__(self, world, I, fns, in_only=False, average=None, negative=False):
+        super().__init__(world, I, fns, in_only, average, negative)
+        if isinstance(world, world_sumo.World):
+            in_lanes_count = 0
+            for road in I.in_roads:
+                for k in I.road_lane_mapping[road]:
+                    in_lanes_count += 1
+
+            out_lanes_count = 0
+            for road in I.out_roads:
+                for k in I.road_lane_mapping[road]:
+                    out_lanes_count += 1
+
+            self.ob_length = in_lanes_count * 3 + out_lanes_count
+        #         # TODO: rank lanes by lane ranking [0,1,2], assume we only have one digit for ranking
+        elif isinstance(world, world_cityflow.World):
+            lanes = world.get_segmented_lane_count()[I.id]
+            size = sum(len(value) for value in lanes.values())
+            self.ob_length = size
+
+    def generate(self):
+        '''
+        generate
+        Generate state or reward based on current simulation state.
+        
+        :param: None
+        :return ret: state or reward
+        '''
+        result = self.world.get_info('segmented_lane_count')
+        lane_counts = [lane_segment for lane_segments in result[self.I.id].values() for lane_segment in lane_segments]
+        ret = np.array(lane_counts)
+
+        return ret
+
 if __name__ == "__main__":
     from world.world_cityflow import World
     world = World("examples/configs.json", thread_num=1)

--- a/trainer/sim2real_trainer.py
+++ b/trainer/sim2real_trainer.py
@@ -921,8 +921,8 @@ class SIM2REALTrainer(BaseTrainer):
     # Loading is set up for parameter sharing, all agents share a network
     def load_shared(self, model_path):
 
-        base_path = sys.path[0] + "/"
-        real_path = base_path + model_path
+        base_path = os.getcwd()
+        real_path = os.path.join(base_path, model_path)
         [ag.load_shared_model(self.agents_sim[0].learning_rate, e="", customized_path=real_path) for ag in self.agents_sim]
         [ag.load_shared_model(self.agents_sim[0].learning_rate, e="", customized_path=real_path) for ag in self.agents_real]
         time_stamp = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))

--- a/world/world_cityflow.py
+++ b/world/world_cityflow.py
@@ -306,7 +306,8 @@ class World(object):
             "history_vehicles": self.get_history_vehicles,
             "phase": self.get_cur_phase,
             "throughput": self.get_cur_throughput,
-            "averate_travel_time": self.get_average_travel_time
+            "averate_travel_time": self.get_average_travel_time,
+            "segmented_lane_count": self.get_segmented_lane_count
             # "action_executed": self.get_executed_action
         }
         self.fns = []
@@ -322,6 +323,7 @@ class World(object):
         # record lanes' vehicles to calculate arrive_leave_time
         self.dic_lane_vehicle_previous_step = {key: None for key in self.all_lanes}
         self.dic_lane_vehicle_current_step = {key: None for key in self.all_lanes}
+        self.dic_lane_vehicle_distance = {key: None for key in self.all_lanes}
         self.dic_vehicle_arrive_leave_time = dict()  # cumulative
 
         print("world built.")
@@ -340,6 +342,7 @@ class World(object):
         self.real_delay= {}
         self.dic_lane_vehicle_previous_step = {key: None for key in self.all_lanes}
         self.dic_lane_vehicle_current_step = {key: None for key in self.all_lanes}
+        self.dic_lane_vehicle_distance = {key: None for key in self.all_lanes}
         self.dic_vehicle_arrive_leave_time = dict()
 
     def _update_arrive_time(self, list_vehicle_arrive):
@@ -396,6 +399,7 @@ class World(object):
 
         # contain outflow lanes
         self.dic_lane_vehicle_current_step = self.eng.get_lane_vehicles()
+        self.dic_lane_vehicle_distance = self.eng.get_vehicle_distance()
 
         # get vehicle list
         self.list_lane_vehicle_current_step = _change_lane_vehicle_dic_to_list(self.dic_lane_vehicle_current_step)
@@ -480,7 +484,47 @@ class World(object):
                 if lane in out_lanes:
                     pressure -= vehicles[lane]
             pressures[i.id] = pressure
+        self.get_segmented_lane_count()
         return pressures
+    
+    def get_segmented_lane_count(self):
+        lane_vehicles = self.dic_lane_vehicle_current_step
+        segmented_lane_counts = {}
+        # divide the lane into 3 parts
+        # kept the last segment edge slightly larger than 1 to also include 
+        # vehicles just pass the lane
+        segments = [0, 1/3, 2/3, 1.1]
+        for i in self.intersections:
+            segmented_lane_counts[i.id] = {}
+            
+            # get the in_lanes and out_lanes first
+            in_lanes = []
+            for road in i.in_roads:
+                from_zero = (road["startIntersection"] == i.id) if self.RIGHT else (
+                        road["endIntersection"] == i.id)
+                for n in range(len(road["lanes"]))[::(1 if from_zero else -1)]:
+                    in_lanes.append(road["id"] + "_" + str(n))
+
+            out_lanes = []
+            for road in i.out_roads:
+                from_zero = (road["endIntersection"] == i.id) if self.RIGHT else (
+                        road["startIntersection"] == i.id)
+                for n in range(len(road["lanes"]))[::(1 if from_zero else -1)]:
+                    out_lanes.append(road["id"] + "_" + str(n))
+
+            for lane in in_lanes:
+                vehicles = lane_vehicles[lane] if lane_vehicles[lane] else []
+                segment_travelled_portions = [self.dic_lane_vehicle_distance[vehicle] / self.lane_length[lane] for vehicle in vehicles]
+                segmented_lane_counts[i.id][lane] = [
+                    len(list(filter(lambda value: segments[segment] <= value < segments[segment+1], segment_travelled_portions)))
+                    for segment in range(len(segments) - 1)
+                ]
+            for lane in out_lanes:
+                segmented_lane_counts[i.id][lane] = [len(lane_vehicles[lane])] if lane_vehicles[lane] else [0]
+        
+        return segmented_lane_counts
+
+
 
     # return [self.dic_lane_waiting_vehicle_count_current_step[lane] for lane in self.list_entering_lanes] + \
     # [-self.dic_lane_waiting_vehicle_count_current_step[lane] for lane in self.list_exiting_lanes]
@@ -708,6 +752,7 @@ class World(object):
         '''
         #  update previous measurement
         self.dic_lane_vehicle_previous_step = self.dic_lane_vehicle_current_step
+        self.dic_lane_vehicle_distance = self.eng.get_vehicle_distance()
 
         if actions is not None:
             for i, action in enumerate(actions):

--- a/world/world_sumo.py
+++ b/world/world_sumo.py
@@ -465,7 +465,8 @@ class World(object):
             "history_vehicles": None,
             "phase": self.get_cur_phase,
             "throughput": self.get_cur_throughput,
-            "average_travel_time": None
+            "average_travel_time": None,
+            "segmented_lane_count": self.get_segmented_lane_count
         }
         self.fns = []
         self.info = {}
@@ -699,7 +700,34 @@ class World(object):
             pressures[i.id] = pressure
         return pressures
         # pass
-
+        
+    def get_segmented_lane_count(self):
+        segmented_lane_counts = {}
+        segments = [0, 1/3, 2/3, 1.1]
+        for i in self.intersections:
+            segmented_lane_counts[i.id] = {}
+            in_lanes = []
+            for road in i.in_roads:
+                for k in i.road_lane_mapping[road]:
+                    in_lanes.append(k)
+            
+            out_lanes = []
+            for road in i.out_roads:
+                for k in i.road_lane_mapping[road]:
+                    out_lanes.append(k)
+            
+            for lane in in_lanes:
+                vehicles = i.full_observation[lane]['vehicles']
+                segment_travelled_portions = [vehicle['position']/self.eng.lane.getLength(lane) for vehicle in vehicles]
+                segmented_lane_counts[i.id][lane] = [
+                    len(list(filter(lambda value: segments[segment] <= value < segments[segment+1], segment_travelled_portions)))
+                    for segment in range(len(segments) - 1)
+                ]
+            for lane in out_lanes:
+                segmented_lane_counts[i.id][lane] = [len(i.full_observation[lane]['vehicles'])]
+        
+        return segmented_lane_counts
+    
     def get_lane_waiting_time_count(self):
         '''
         get_lane_waiting_time_count


### PR DESCRIPTION
For the state vector,
    1. Current phase of the intersection added (it was already added when you set the phase and onehot configuration to 'true')
    2. Added outgoing lanes
    3. Incoming lanes is now segmented into 3 parts

For the reward, 
I set the reward to pressure. 

This should work as a nice base. I made some preliminary testing and the code seems to work. 

There is one quirk with the code tho. In the observation vector, the order of the incoming and outgoing lanes is not consistent between SUMO and CityFlow. I am not sure how much of an issue this will be. If you want it, I will add a fix later. Just check if this is the code you want.

Let me know of any issues you find.