### PR TITLE
aligned the lanes for SUMO and CityFlow

### DIFF
--- a/world/world_cityflow.py
+++ b/world/world_cityflow.py
@@ -2,6 +2,7 @@ import json
 import os
 import cityflow
 from common.registry import Registry
+from collections import OrderedDict
 
 import numpy as np
 from math import atan2, pi
@@ -489,13 +490,13 @@ class World(object):
     
     def get_segmented_lane_count(self):
         lane_vehicles = self.dic_lane_vehicle_current_step
-        segmented_lane_counts = {}
+        segmented_lane_counts = OrderedDict()
         # divide the lane into 3 parts
         # kept the last segment edge slightly larger than 1 to also include 
         # vehicles just pass the lane
         segments = [0, 1/3, 2/3, 1.1]
         for i in self.intersections:
-            segmented_lane_counts[i.id] = {}
+            segmented_lane_counts[i.id] = OrderedDict()
             
             # get the in_lanes and out_lanes first
             in_lanes = []
@@ -511,6 +512,10 @@ class World(object):
                         road["startIntersection"] == i.id)
                 for n in range(len(road["lanes"]))[::(1 if from_zero else -1)]:
                     out_lanes.append(road["id"] + "_" + str(n))
+            
+            # make sure lanes match with SUMO
+            in_lanes.sort()        
+            out_lanes.sort()
 
             for lane in in_lanes:
                 vehicles = lane_vehicles[lane] if lane_vehicles[lane] else []

--- a/world/world_sumo.py
+++ b/world/world_sumo.py
@@ -4,6 +4,7 @@ Part of this code is borrowed from RESCO: https://github.com/Pi-Star-Lab/RESCO
 
 import os
 import sys
+from collections import OrderedDict
 from math import atan2, pi
 import xml.etree.cElementTree as ET
 
@@ -702,10 +703,10 @@ class World(object):
         # pass
         
     def get_segmented_lane_count(self):
-        segmented_lane_counts = {}
+        segmented_lane_counts = OrderedDict()
         segments = [0, 1/3, 2/3, 1.1]
         for i in self.intersections:
-            segmented_lane_counts[i.id] = {}
+            segmented_lane_counts[i.id] = OrderedDict()
             in_lanes = []
             for road in i.in_roads:
                 for k in i.road_lane_mapping[road]:
@@ -715,7 +716,11 @@ class World(object):
             for road in i.out_roads:
                 for k in i.road_lane_mapping[road]:
                     out_lanes.append(k)
-            
+
+            # make sure lanes match with CityFlow
+            in_lanes.sort()        
+            out_lanes.sort()
+
             for lane in in_lanes:
                 vehicles = i.full_observation[lane]['vehicles']
                 segment_travelled_portions = [vehicle['position']/self.eng.lane.getLength(lane) for vehicle in vehicles]


### PR DESCRIPTION
The lane order is now aligned in both SUMO and CityFlow. Just sorting the lane names did the trick.